### PR TITLE
Added support for Z-Way Authentication token.

### DIFF
--- a/lib/zway-socket.js
+++ b/lib/zway-socket.js
@@ -76,7 +76,7 @@ class ZWaySocket extends EventEmitter {
     parseData(data) {
         try {
             var jsonRoot = JSON.parse(data);
-            var msg = JSON.parse(jsonRoot.data)
+            var msg = jsonRoot.data;
             return msg;
         } catch (err) {
             return this.emit('error', err);

--- a/lib/zway-socket.js
+++ b/lib/zway-socket.js
@@ -3,6 +3,7 @@ const WebSocket = require('ws');
 
 class ZWaySocket extends EventEmitter {
     constructor({
+                    authToken,
                     hostname,
                     port = 8083,
                     secure = false,
@@ -14,6 +15,7 @@ class ZWaySocket extends EventEmitter {
                 }={}) {
         super();
 
+        this.authToken = authToken;
         this.hostname = hostname;
         this.port = port;
         this.secure = secure;
@@ -46,9 +48,11 @@ class ZWaySocket extends EventEmitter {
         }
 
         try {
-            var address = this.buildAddress()
-            console.log(address)
-            this.socket = new WebSocket(address);
+            var address = this.buildAddress();
+            console.log(address);
+            var headers = {};
+            if (this.authToken) headers["Authorization"] = "Bearer " + this.authToken;
+            this.socket = new WebSocket(address, { headers: headers });
         } catch (err) {
             this.onClose(err);
             throw err;

--- a/nodes/out.js
+++ b/nodes/out.js
@@ -225,7 +225,7 @@ module.exports = function(RED) {
                         node.status({}); //clean
                     }, 3000);
                 }
-            }).auth(node.server.login, node.server.pass);
+            }).auth(null, null, true, node.server.authToken);
         }
 
         formatHomeKit(message, payload) {

--- a/nodes/server.html
+++ b/nodes/server.html
@@ -14,12 +14,8 @@
         <input type="text" id="node-config-input-port">
     </div> -->
     <div class="form-row">
-        <label for="node-config-input-login" class="l-width"><i class="icon-lock"></i> User </span></label>
-        <input type="text" id="node-config-input-login">
-    </div>
-    <div class="form-row">
-        <label for="node-config-input-pass" class="l-width"><i class="icon-lock"></i> Password</span></label>
-        <input type="password" id="node-config-input-pass">
+        <label for="node-config-input-authToken" class="l-width"><i class="icon-lock"></i> Z-Way authorization token </span></label>
+        <input type="text" id="node-config-input-authToken">
     </div>
     <!-- <div class="form-row">
         <label for="node-config-input-secure" class="l-width"><i class="icon-tag"></i> SSL</label>
@@ -45,14 +41,10 @@
                 required: true,
                 validate:RED.validators.number()
             },
-            login: {
+            autToken: {
                 value: null,
                 required: true
             },
-            pass: {
-                value: null,
-                required: true
-            }
             // secure: {
             //     value: false,
             //     required: true

--- a/nodes/server.html
+++ b/nodes/server.html
@@ -41,7 +41,7 @@
                 required: true,
                 validate:RED.validators.number()
             },
-            autToken: {
+            authToken: {
                 value: null,
                 required: true
             },

--- a/nodes/server.js
+++ b/nodes/server.js
@@ -23,7 +23,7 @@ module.exports = function(RED) {
             node.refreshDiscoverInterval = 15000;
 
             node.socket = new ZWaySocket({
-                authToken: this.autToken,
+                authToken: this.authToken,
                 hostname: this.ip,
                 secure: this.secure
             });

--- a/nodes/server.js
+++ b/nodes/server.js
@@ -14,8 +14,7 @@ module.exports = function(RED) {
             node.name = n.name;
             node.ip = n.ip;
             node.port = 8083;
-            node.login = n.login;
-            node.pass = n.pass;
+            node.authToken = n.authToken;
             node.secure = n.secure || false;
             node.devices = {};
 
@@ -24,6 +23,7 @@ module.exports = function(RED) {
             node.refreshDiscoverInterval = 15000;
 
             node.socket = new ZWaySocket({
+                authToken: this.autToken,
                 hostname: this.ip,
                 secure: this.secure
             });
@@ -86,7 +86,7 @@ module.exports = function(RED) {
                     node.discoverProcess = false;
                     callback(node.items);
                     return node.items;
-                }).auth(node.login, node.pass);
+                }).auth(null, null, true, node.authToken);
             } else {
                 node.log('discoverDevices: Using cached devices');
                 callback(node.items);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/bkorda/node-red-contrib-zway/issues/"
   },
   "dependencies": {
-    "multiple-select": "^1.4.1",
+    "multiple-select": "^1.5.2",
     "request": "latest",
     "ws": "latest",
     "events": "latest"


### PR DESCRIPTION
Starting from v3.2.0 Z-Way requires Websocket API to be authenticate like HTTP API. This changes the node-red integration module to use the Z-Way auth token instead of login/pass.

You can change back to login/pass and autodetect the token from the first discoverDevices. Up to you

NB! This was not tested - please check before merging.

Should fix: #10 